### PR TITLE
Add support for Python 3 and Pickable hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
-*.pyc
 /MANIFEST
 /dist/
+
+.idea/
+
+*.pyc
+__pycache__/

--- a/perfection/czech.py
+++ b/perfection/czech.py
@@ -3,6 +3,8 @@
 Use the Czech et al. method for generating minimal perfect hashes for strings.
 """
 
+from __future__ import print_function
+
 import random
 import collections
 
@@ -247,12 +249,9 @@ def make_hash(words, *args, **kwargs):
     >>> hf('sun')
     0
     """
-
     # Use the hash builder proper, because HashInfo is assumed to not
     # have the precious f1, and f2 attributes.
-    info = CzechHashBuilder(words, *args, **kwargs)
-
-    return info.hash_function
+    return CzechHashBuilder(words, *args, **kwargs).hash_function
 
 
 def make_dict(name, words, *args, **kwargs):
@@ -298,20 +297,6 @@ def to_hash_info(unknown):
         # Unknown is a CzechHash.
         return unknown
     return HashInfo(unknown)
-
-    # Alternative method:
-    def _exception_based():
-        try:
-            (unknown.t1, unknown.t2, unknown.f1, unknown.f2, unknown.g)
-        except AttributeError:
-            return CreateCzechHash(unknown)
-        try:
-            for attr in ('t1', 't2', 'f1', 'f2', 'g'):
-                iter(getattr(unknown, attr))
-        except TypeError:
-            return CreateCzechHash(unknown)
-
-        return unknown
 
 
 def do_example():

--- a/perfection/czech.py
+++ b/perfection/czech.py
@@ -42,7 +42,7 @@ class CzechHashBuilder(object):
         self.words = ordered_deduplicate(words)
 
         # TODO: Index minimization
-        self.indices = range(len(words[0]))
+        self.indices = list(range(len(words[0])))
 
         # Each of the following steps add fields to `self`:
 
@@ -101,7 +101,7 @@ class CzechHashBuilder(object):
         self.n = 3 * len(self.words)
 
         max_tries = len(self.words) ** 2
-        for trial in xrange(max_tries):
+        for trial in range(max_tries):
             try:
                 self.generate_or_fail()
             except forest.InvariantError:
@@ -118,7 +118,7 @@ class CzechHashBuilder(object):
         """
         Generates random tables for given word lists.
         """
-        table = range(0, self.n)
+        table = list(range(0, self.n))
         random.shuffle(table)
         return table
 
@@ -141,7 +141,7 @@ class CzechHashBuilder(object):
 
         # Associate each edge with its corresponding word.
         associations = {}
-        for num in xrange(len(self.words)):
+        for num in range(len(self.words)):
             edge = edges[num]
             word = self.words[num]
             associations[graph.canonical_order(edge)] = (num, word)
@@ -320,10 +320,10 @@ def do_example():
 
     hb = CzechHashBuilder(words)
 
-    print '/*', hb.t1, hb.t2, hb.g, '*/'
-    print hb.graph.to_dot(edge_labels={
-        edge: '%d: %s' % assoc for edge, assoc in hb.associations.items()
-    })
+    print('/*', hb.t1, hb.t2, hb.g, '*/')
+    print(hb.graph.to_dot(edge_labels={
+        edge: '%d: %s' % assoc for edge, assoc in list(hb.associations.items())
+        }))
 
 
 if __name__ == '__main__':

--- a/perfection/forest.py
+++ b/perfection/forest.py
@@ -114,7 +114,7 @@ class ForestGraph(object):
         """
         canonical_edges = set()
 
-        for v1, neighbours in self._vertices.items():
+        for v1, neighbours in list(self._vertices.items()):
             for v2 in neighbours:
                 edge = self.canonical_order((v1, v2))
                 canonical_edges.add(edge)
@@ -124,7 +124,7 @@ class ForestGraph(object):
     @property
     def vertices(self):
         """Set of all vertices in the graph."""
-        return self._vertices.viewkeys()
+        return self._vertices.keys()
 
     def neighbours(self, vertex):
         """
@@ -180,7 +180,7 @@ def print_example_graph():
     for c in 'uvwxy':
         l[c] = c
     g = ForestGraph(edges=[(u, w), (w, x), (v,y)])
-    print g.to_dot()
+    print(g.to_dot())
 
 if __name__ == '__main__':
     import sys

--- a/perfection/forest.py
+++ b/perfection/forest.py
@@ -1,17 +1,19 @@
 #!/usr/bin/env python
-
 """
 Includes the ForestGraph, which is pretty much just intended to be used to ...
 do stuff.
-
 """
+
+from __future__ import print_function
 
 import collections
 
 __all__ = ['InvariantError', 'ForestGraph']
 
+
 class InvariantError(ValueError):
     pass
+
 
 class ForestGraph(object):
     """
@@ -113,13 +115,11 @@ class ForestGraph(object):
         Edges of this graph, in canonical order.
         """
         canonical_edges = set()
-
-        for v1, neighbours in list(self._vertices.items()):
+        for v1, neighbours in self._vertices.items():
             for v2 in neighbours:
                 edge = self.canonical_order((v1, v2))
                 canonical_edges.add(edge)
         return canonical_edges
-
 
     @property
     def vertices(self):
@@ -131,10 +131,7 @@ class ForestGraph(object):
         Yields all neighbours of the given vertex, in no particular
         order.
         """
-
         return self._vertices[vertex]
-
-
 
     @staticmethod
     def canonical_order(edge):
@@ -147,8 +144,10 @@ class ForestGraph(object):
         return ''.join((cls_name, '(', args, ')'))
 
 
+def graph_as_dot(edge_set, edge_labels=None, indentation=4):
+    if not edge_labels:
+        edge_labels = {}
 
-def graph_as_dot(edge_set, edge_labels={}, indentation=4):
     indent = ' ' * indentation
     edge_tmpl = indent + '"{u}" -- "{v}"{label};'
 

--- a/perfection/getty.py
+++ b/perfection/getty.py
@@ -71,7 +71,7 @@ def hash_parameters(keys, minimize=True, to_int=None):
     key_to_original = {to_int(original): original for original in keys}
 
     # Create a set of all items to be hashed.
-    items = key_to_original.keys()
+    items = list(key_to_original.keys())
 
     if minimize:
         offset = 0 - min(items)
@@ -131,7 +131,7 @@ def place_items_in_square(items, t):
     # Each item is a tuple of (t - |row|, y, [(xpos_1, item_1), ...]).
     # Until the call to heapq.heapify(), the rows are ordered in
     # increasing row number (y).
-    rows = [(t, y, []) for y in xrange(t)]
+    rows = [(t, y, []) for y in range(t)]
 
     for item in items:
         # Calculate the cell the item should fall in.
@@ -177,7 +177,7 @@ def arrange_rows(row_queue, t):
 
     # Create a set of all of the unoccupied columns.
     max_columns = t ** 2
-    cols = ((x, True) for x in xrange(max_columns))
+    cols = ((x, True) for x in range(max_columns))
     unoccupied_columns = collections.OrderedDict(cols)
 
     # Create the resultant and displacement vectors.
@@ -213,7 +213,7 @@ def find_first_fit(unoccupied_columns, row, row_length):
             return offset
 
     raise ValueError("Row cannot bossily fit in %r: %r"
-                     % (unoccupied_columns.keys(), row))
+                     % (list(unoccupied_columns.keys()), row))
 
 
 def check_columns_fit(unoccupied_columns, row, offset, row_length):
@@ -249,18 +249,18 @@ def print_square(row_queue, t):
     """
     occupied_rows = {y: row for _, y, row in row_queue}
 
-    empty_row = ', '.join('...' for _ in xrange(t))
-    for y in xrange(t):
-        print '|',
+    empty_row = ', '.join('...' for _ in range(t))
+    for y in range(t):
+        print('|', end=' ')
         if y not in occupied_rows:
-            print empty_row,
+            print(empty_row, end=' ')
         else:
             row = dict(occupied_rows[y])
             all_cols = ('%3d' % row[x] if x in row else '...'
-                        for x in xrange(t))
-            print ', '.join(all_cols),
+                        for x in range(t))
+            print(', '.join(all_cols), end=' ')
 
-        print "|"
+        print("|")
 
 
 def trim_nones_from_right(xs):

--- a/perfection/getty.py
+++ b/perfection/getty.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # coding: utf-8
 
+from __future__ import print_function
+
 import math
 import collections
 import heapq
@@ -11,7 +13,6 @@ __all__ = ['hash_parameters', 'make_hash', 'make_dict']
 
 
 HashInfo = collections.namedtuple('HashInfo', 't slots r offset to_int')
-
 
 __identity = lambda x: x
 
@@ -307,7 +308,6 @@ def make_hash(keys, **kwargs):
     # Undocumented properties, but used in make_dict()...
     perfect_hash.length = len(params.slots)
     perfect_hash.slots = params.slots
-
     return perfect_hash
 
 
@@ -331,7 +331,6 @@ def make_dict(name, keys, **kwargs):
     >>> len(d)
     2
     """
-
     hash_func = make_hash(keys, **kwargs)
     slots = hash_func.slots
 


### PR DESCRIPTION
This pull request adds support for Python 3 and is still compatible with Python 2.7+.
It also add a pickable version of ``make_hash()``, allowing the generated function to be broadcasted to a set of workers using ``pickle``.