### PR TITLE
 * fix: open Readme.rst failed when install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author='Eddie Antonio Santos',
     author_email='easantos@ualberta.ca',
     description='Perfect hashing utilities for Python',
-    long_description=open('README.rst').read(),
+    long_description=open('README.rst',encoding="UTF-8").read(),
     packages=['perfection',],
     platforms='any',
     classifiers=[


### PR DESCRIPTION
When trying to install perfection on python 3.7, Simplified Chineses Windows 10, I got the following error:

```
f:\BaiduYun\Documents\课程\程序设计基础python\讲义v1>pip install perfection
Looking in indexes: https://pypi.tuna.tsinghua.edu.cn/simple
Collecting perfection
  Downloading https://pypi.tuna.tsinghua.edu.cn/packages/4e/c0/fdd5adbdbb976cfd7ce996cfa3b841813772230f712c13645e353fe3efb5/perfection-2.0.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\Roy\AppData\Local\Temp\pip-install-astzhvap\perfection\setup.py", line 12, in <module>
        long_description=open('README.rst').read(),
    UnicodeDecodeError: 'gbk' codec can't decode byte 0x94 in position 53: illegal multibyte sequence

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in C:\Users\Roy\AppData\Local\Temp\pip-install-astzhvap\perfection\
```

This patch fixes it.